### PR TITLE
feat: 내 교환,판매 카드 불러오는 api 구현

### DIFF
--- a/src/cards/dto/exchangeCards/my-exchange-card.dto.ts
+++ b/src/cards/dto/exchangeCards/my-exchange-card.dto.ts
@@ -47,6 +47,7 @@ export class GetMyExchangeCardResponseDto extends CardDto {
     response.description = exchange.offeredCard.description;
     response.grade = exchange.offeredCard.grade;
     response.genre = exchange.offeredCard.genre;
+    response.totalQuantity = 1;
     response.price = exchange.offeredCard.price;
     response.createdAt = exchange.createdAt;
     response.updatedAt = exchange.updatedAt;

--- a/src/cards/dto/exchangeCards/my-exchange-card.dto.ts
+++ b/src/cards/dto/exchangeCards/my-exchange-card.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { CardDto } from '../cards.dto';
+import { createId } from '@paralleldrive/cuid2';
+import { Exchange, Card } from '@prisma/client';
+
+type ExchangeWithRelations = Exchange & {
+  offeredCard: Card & {
+    owner: {
+      nickname: string;
+    };
+  };
+};
+
+export class GetMyExchangeCardResponseDto extends CardDto {
+  @ApiProperty({
+    nullable: false,
+    description: '교환 대상 카드의 ID',
+    example: createId(),
+    type: String,
+  })
+  @IsString()
+  targetId: string;
+
+  @ApiProperty({
+    nullable: false,
+    default: 'nickname',
+    description: '카드 소유자의 닉네임',
+  })
+  @IsString()
+  nickname: string;
+
+  @ApiProperty({
+    nullable: false,
+    default: 'exchange',
+    description: '카드의 판매 방법',
+  })
+  @IsString()
+  state: 'exchange';
+
+  static of(exchange: ExchangeWithRelations): GetMyExchangeCardResponseDto {
+    const response = new GetMyExchangeCardResponseDto();
+    response.targetId = exchange.targetCardId;
+    response.id = exchange.offeredCard.id;
+    response.ownerId = exchange.requesterId;
+    response.name = exchange.offeredCard.name;
+    response.description = exchange.offeredCard.description;
+    response.grade = exchange.offeredCard.grade;
+    response.genre = exchange.offeredCard.genre;
+    response.price = exchange.offeredCard.price;
+    response.createdAt = exchange.createdAt;
+    response.updatedAt = exchange.updatedAt;
+    response.nickname = exchange.offeredCard.owner.nickname;
+    response.state = 'exchange';
+    return response;
+  }
+}

--- a/src/cards/dto/sellingCards/my-selling-card.dto.ts
+++ b/src/cards/dto/sellingCards/my-selling-card.dto.ts
@@ -1,0 +1,141 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Card, CardGenre, CardGrade, Shop } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { CardDto } from '../cards.dto';
+import { createId } from '@paralleldrive/cuid2';
+
+type SellingCardWithRelations = Shop & {
+  card: Card & {
+    owner: {
+      nickname: string;
+    };
+  };
+};
+
+export class GetMyCardsRequestDto {
+  @ApiProperty({
+    required: false,
+    enum: CardGrade,
+    description: '카드 등급으로 필터링(optional)',
+  })
+  @IsOptional()
+  @ValidateIf((o) => !o.genre && !o.stockState && !o.keyword)
+  @IsEnum(CardGrade)
+  grade?: CardGrade;
+
+  @ApiProperty({
+    required: false,
+    enum: CardGenre,
+    description: '카드 장르로 필터링(optional)',
+  })
+  @IsOptional()
+  @ValidateIf((o) => !o.grade && !o.stockState && !o.keyword)
+  @IsEnum(CardGenre)
+  genre?: CardGenre;
+
+  @ApiProperty({
+    required: false,
+    enum: ['IN_STOCK', 'OUT_OF_STOCK'],
+    description: '판매 상태로 필터링(optional)',
+  })
+  @IsOptional()
+  @ValidateIf((o) => !o.genre && !o.grade && !o.keyword)
+  @IsEnum(['IN_STOCK', 'OUT_OF_STOCK'])
+  stockState?: string;
+
+  @ApiProperty({
+    required: false,
+    enum: ['EXCHANGE', 'SALE'],
+    description: '판매 방법으로 필터링(optional)',
+  })
+  @IsOptional()
+  @ValidateIf((o) => !o.genre && !o.grade && !o.keyword)
+  @IsEnum(['EXCHANGE', 'SALE'])
+  salesMethod?: string;
+
+  @ApiProperty({
+    required: false,
+    description: '검색 키워드 (카드 이름, 설명에서 검색) (optional)',
+  })
+  @IsOptional()
+  @ValidateIf((o) => !o.genre && !o.stockState && !o.grade)
+  @IsString()
+  keyword?: string;
+
+  @ApiProperty({
+    required: false,
+    default: 1,
+    description: '페이지 번호 (1부터 시작)(optional)',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiProperty({
+    required: false,
+    default: 30,
+    description: '페이지당 항목 수(optional)',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 30;
+}
+
+export class GetMySellingCardResponseDto extends CardDto {
+  @ApiProperty({
+    nullable: false,
+    description:
+      '판매 ID (서버에서 CUID 형식으로 자동 생성되며, 클라이언트가 값을 제공할 필요 없음)',
+    example: createId(),
+    type: String,
+  })
+  @IsString()
+  targetId: string;
+
+  @ApiProperty({
+    nullable: false,
+    default: 'nickname',
+    description: '카드 소유자의 닉네임',
+  })
+  @IsString()
+  nickname: string;
+
+  @ApiProperty({
+    nullable: false,
+    default: 'sale',
+    description: '카드의 판매 방법',
+  })
+  @IsString()
+  state: 'sale';
+
+  static of(shop: SellingCardWithRelations): GetMySellingCardResponseDto {
+    const response = new GetMySellingCardResponseDto();
+    response.targetId = shop.id;
+    response.id = shop.card.id;
+    response.ownerId = shop.sellerId;
+    response.nickname = shop.card.owner.nickname;
+    response.name = shop.card.name;
+    response.description = shop.card.description;
+    response.grade = shop.card.grade;
+    response.genre = shop.card.genre;
+    response.price = shop.price;
+    response.createdAt = shop.createdAt;
+    response.updatedAt = shop.updatedAt;
+    response.state = 'sale';
+    return response;
+  }
+}

--- a/src/cards/dto/sellingCards/my-selling-card.dto.ts
+++ b/src/cards/dto/sellingCards/my-selling-card.dto.ts
@@ -133,6 +133,7 @@ export class GetMySellingCardResponseDto extends CardDto {
     response.grade = shop.card.grade;
     response.genre = shop.card.genre;
     response.price = shop.price;
+    response.totalQuantity = shop.quantity;
     response.createdAt = shop.createdAt;
     response.updatedAt = shop.updatedAt;
     response.state = 'sale';

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -32,6 +32,7 @@ import { Express } from 'express';
 import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { existsSync, mkdirSync } from 'fs';
+import { GetMyCardsRequestDto } from 'src/cards/dto/sellingCards/my-selling-card.dto';
 
 @Controller('users')
 export class UsersController {
@@ -346,5 +347,42 @@ export class UsersController {
   async getUserPhotoCardInfo(@GetUser() user: { userId: string }) {
     const { userId } = user;
     return this.usersService.getUserPhotoCardInfo(userId);
+  }
+
+  @Get('my-cards/sales')
+  @UseGuards(AuthGuard)
+  @ApiOperation({ summary: '내 판매 카드 목록 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '내 판매 카드 조회 성공',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 데이터',
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 정보가 존재하지 않습니다.',
+  })
+  @ApiResponse({
+    status: 500,
+    description: '판매 카드 조회 중 오류가 발생했습니다.',
+  })
+  async getMySellingCards(
+    @GetUser() user: { userId: string },
+    @Query() params: GetMyCardsRequestDto,
+  ) {
+    try {
+      return await this.usersService.getMySellingCards(user.userId, params);
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        throw new InternalServerErrorException(
+          '데이터베이스 조회 중 오류가 발생했습니다.',
+        );
+      }
+      throw new InternalServerErrorException(
+        '판매 카드 조회 중 오류가 발생했습니다.',
+      );
+    }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -362,6 +362,7 @@ export class UsersService {
           select: {
             id: true,
             price: true,
+            quantity: true,
             sellerId: true,
             createdAt: true,
             updatedAt: true,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -17,6 +17,11 @@ import {
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { CreateCardDto } from 'src/cards/dto/create-card.dto';
 import { Card, CardGenre, CardGrade, Prisma, User } from '@prisma/client';
+import {
+  GetMyCardsRequestDto,
+  GetMySellingCardResponseDto,
+} from 'src/cards/dto/sellingCards/my-selling-card.dto';
+import { GetMyExchangeCardResponseDto } from 'src/cards/dto/exchangeCards/my-exchange-card.dto';
 
 @Injectable()
 export class UsersService {
@@ -318,6 +323,130 @@ export class UsersService {
       rare,
       superRare,
       legendary,
+    };
+  }
+
+  async getMySellingCards(userId: string, params: GetMyCardsRequestDto) {
+    const { grade, genre, stockState, salesMethod, keyword } = params;
+    const page = Number(params.page) ?? 1;
+    const limit = Number(params.limit) ?? 30;
+    const skip = (page - 1) * limit;
+
+    const cardWhere = {
+      ...(grade && { grade }),
+      ...(genre && { genre }),
+      ...(stockState && {
+        remainingQuantity:
+          stockState === 'IN_STOCK' ? { gt: 0 } : { equals: 0 },
+      }),
+      ...(keyword && {
+        OR: [
+          { name: { contains: keyword } },
+          { description: { contains: keyword } },
+        ],
+      }),
+    };
+
+    let sellingCards = [];
+    let exchangeCards = [];
+    let shopTotal = 0;
+    let exchangeTotal = 0;
+
+    if (!salesMethod || salesMethod === 'SALE') {
+      [sellingCards, shopTotal] = await Promise.all([
+        this.prisma.shop.findMany({
+          where: {
+            sellerId: userId,
+            card: cardWhere,
+          },
+          select: {
+            id: true,
+            price: true,
+            sellerId: true,
+            createdAt: true,
+            updatedAt: true,
+            card: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+                grade: true,
+                genre: true,
+                owner: {
+                  select: {
+                    nickname: true,
+                  },
+                },
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        }),
+        this.prisma.shop.count({
+          where: {
+            sellerId: userId,
+            card: cardWhere,
+          },
+        }),
+      ]);
+    }
+
+    if (!salesMethod || salesMethod === 'EXCHANGE') {
+      [exchangeCards, exchangeTotal] = await Promise.all([
+        this.prisma.exchange.findMany({
+          where: {
+            requesterId: userId,
+            offeredCard: cardWhere,
+          },
+          select: {
+            id: true,
+            targetCardId: true,
+            createdAt: true,
+            updatedAt: true,
+            offeredCard: {
+              select: {
+                id: true,
+                name: true,
+                description: true,
+                price: true,
+                grade: true,
+                genre: true,
+                owner: {
+                  select: {
+                    nickname: true,
+                  },
+                },
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        }),
+        this.prisma.exchange.count({
+          where: {
+            requesterId: userId,
+          },
+        }),
+      ]);
+    }
+
+    const allCards = [...sellingCards, ...exchangeCards]
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(skip, skip + limit);
+
+    const total = shopTotal + exchangeTotal;
+
+    return {
+      items: allCards.map((card) =>
+        'price' in card
+          ? GetMySellingCardResponseDto.of(card)
+          : GetMyExchangeCardResponseDto.of(card),
+      ),
+      meta: {
+        page,
+        limit,
+        total,
+        totalPage: Math.ceil(total / limit),
+      },
     };
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 사용자의 판매 및 교환 카드를 필터링하여 조회할 수 있는 기능 추가
	- 카드 검색 시 등급, 장르, 재고 상태, 판매 방법 등 다양한 조건으로 필터링 가능
	- 페이지네이션 지원으로 카드 목록을 효율적으로 탐색 가능
	- 사용자의 판매 카드 목록을 조회할 수 있는 새로운 엔드포인트 추가

- **개선 사항**
	- 카드 조회 응답 구조 최적화
	- Swagger 문서화를 통한 API 가독성 향상
	- 오류 처리 기능 추가로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->